### PR TITLE
Fix Hover Flickering on Tab Button

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -430,6 +430,7 @@ progress::-webkit-progress-value  /* Filled part of the progress bar (WebKit) */
 	max-width: 50vw !important;         /* Limit maximum width */
     width: fit-content !important;      /* Fit width to content */
     transition: background-color 0.2s ease; /* Smooth background transition */
+    border-radius: 100px !important;    /* Start with applied Border Radius */
 }
 /* Desktop-specific margin for tab/home buttons. */
 .layout-desktop .homeLibraryButton,


### PR DESCRIPTION
Greetings, while trying out your theme I've noticed that the header tab buttons don't have their border radius applied when the user does not hover over them. 
So when you move your mouse away again, the background is visible as a rectangle before it goes transparent. Also behaves like this on mobile.

[VisualBug.webm](https://github.com/user-attachments/assets/8d4b5eba-0027-4344-81eb-f71b030b06d3)


I've added the radius that's being applied on hover on the non-hover class as well, which solves this visual bug for me:

[WithBorderRadius.webm](https://github.com/user-attachments/assets/82173c59-ad40-4c82-8fef-c74e9088a0df)

Thanks for the theme by the way, I really enjoy it so far!



