### PR TITLE
fix tabs section width  on TV layout for 10.11

### DIFF
--- a/10.11_fixes.css
+++ b/10.11_fixes.css
@@ -45,3 +45,8 @@ div#listChildrenCollapsible {
     top: 0% !important;
 
 }
+
+.layout-tv .sectionTabs {
+	width: fit-content;
+	margin-inline: auto !important;
+}


### PR DESCRIPTION
Before:
<img width="1427" height="487" alt="Screenshot 2025-10-25 at 18 06 32" src="https://github.com/user-attachments/assets/8dff9b70-614e-4365-ab61-e4e047313dc5" />

After:
<img width="1426" height="442" alt="Screenshot 2025-10-25 at 18 07 00" src="https://github.com/user-attachments/assets/d8285434-c43e-4ef6-9400-a796cd4d96d2" />
