### PR TITLE
Fix: Remove headerLeft background in @supports fallback for JMP

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -564,7 +564,7 @@ progress::-webkit-progress-value  /* Filled part of the progress bar (WebKit) */
     .layout-desktop .headerLeft {
         padding: 2px !important;
         top: -3px !important;
-        background-color: var(--primary-background-transparent) !important; /* Fallback background */
+        background-color: transparent !important; /* Keep transparent for fallback to match modern browser behavior */
         border-radius: 50px !important; /* Different rounding for fallback */
     }
 }


### PR DESCRIPTION
## Problem
In Jellyfin Media Player (desktop client), a semi-transparent colored bar appears across the top of the
interface. This does not occur in web browsers.

<img width="1280" alt="Before: Semi-transparent colored bar visible in header" src="https://github.com/user-attachments/assets/5416a43b-73c3-4955-850a-7ad768c87f51" />

## Root Cause
The `@supports not selector(:has(*))` fallback block (lines 563-570 in `theme.css`) adds
`background-color: var(--primary-background-transparent)` to `.headerLeft` for browsers that don't support
the CSS `:has()` selector.

Jellyfin Media Player uses QtWebEngine, which doesn't support `:has()`, so it uses this fallback. However,
the main `.headerLeft` rule for modern browsers (line 559) does NOT set any background, creating a visual
inconsistency.

## Solution
Changed the fallback's `background-color` from `var(--primary-background-transparent)` to `transparent` to
match the modern browser behavior.

This is a one-line change that removes the unwanted colored bar in JMP while maintaining all other
fallback styling (padding, border-radius, etc.).

<img width="1280" alt="After: Header now fully transparent" src="https://github.com/user-attachments/assets/17cb8996-8d12-495a-a1e4-721c3dac9eb4" />

## Testing
- ✅ Tested in Jellyfin Media Player 1.11.1 (macOS) - colored bar removed
- ✅ Tested in Firefox - no visual changes (uses main rule, not fallback)
- ✅ Header functionality unchanged - buttons and navigation work as expected
- ✅ Tested with multiple color schemes (lavender, blue) - fix works universally
